### PR TITLE
Scoring fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Orange3 Data Fusion
 ===================
 
 This is a data fusion add-on for [Orange3](http://orange.biolab.si). Add-on
-wraps a python library TBD for data fusion and implements a set of widgets
-for loading of the data, definition of data fusion schema, collective matrix
-factorization and exploration of latent factors.
+wraps [scikit-fusion](http://github.com/marinkaz/scikit-fusion), a Python library for 
+data fusion, and implements a set of widgets for loading of the data, definition of 
+data fusion schema, collective matrix factorization and exploration of latent factors.
 
 Installation
 ------------

--- a/orangecontrib/datafusion/widgets/owmeanfuser.py
+++ b/orangecontrib/datafusion/widgets/owmeanfuser.py
@@ -52,6 +52,8 @@ class MeanFuser(RelationCompleter):
         A = relation.data.copy()
         if not np.ma.is_masked(A):
             return A
+        # Compute mean values on training data
+        A.mask = 1 - A.mask
         mean_value = np.nanmean(A, axis=None)
         if self.axis is None:
             # Replace the mask with mean of the matrix
@@ -65,8 +67,7 @@ class MeanFuser(RelationCompleter):
         return A
 
 
-# class OWMeanFuser(widget.OWWidget):
-class OWMeanFuser(widget.ToBeRevisedFixed):
+class OWMeanFuser(widget.OWWidget):
     name = 'Mean Fuser'
     priority = 55000
     icon = 'icons/MeanFuser.svg'

--- a/orangecontrib/datafusion/widgets/owmovieratings.py
+++ b/orangecontrib/datafusion/widgets/owmovieratings.py
@@ -5,7 +5,6 @@ from Orange.widgets import widget, gui, settings
 from orangecontrib.datafusion.models import Relation
 from orangecontrib.datafusion import movielens
 
-import numpy as np
 from skfusion import fusion
 
 class OWMovieRatings(OWWidget):
@@ -70,13 +69,9 @@ class OWMovieRatings(OWWidget):
                 self.error(0, "Invalid starting years")
                 self.send("Ratings", None)
 
-        def scale(X):
-            return (X - np.nanmin(X)) / (np.nanmax(X) - np.nanmin(X))
-
         relation = fusion.Relation(matrix.T, name='rate',
                                    row_type=movielens.ObjectType.Users, row_names=users,
-                                   col_type=movielens.ObjectType.Movies, col_names=movies,
-                                   preprocessor=scale)
+                                   col_type=movielens.ObjectType.Movies, col_names=movies)
         self.send("Ratings", Relation(relation))
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove scaling of predictions to [0,1]. This improves interpretability. 
- Include OwMeanFuser, which now computes mean values on training data. 
- Remove scaling of predictions in model scoring, which makes scoring generally applicable. 
