### PR TITLE
owfusiongraph: Remove `enterPlaceholder` parameter to gui.lineEdit

### DIFF
--- a/orangecontrib/datafusion/widgets/owfusiongraph.py
+++ b/orangecontrib/datafusion/widgets/owfusiongraph.py
@@ -137,7 +137,7 @@ class OWFusionGraph(widget.OWWidget):
         gui.lineEdit(self.controlArea,
                      self, 'pref_algo_name', 'Fuser name:',
                      orientation='horizontal',
-                     callback=self.checkcommit, enterPlaceholder=True)
+                     callback=self.checkcommit)
         gui.radioButtons(self.controlArea,
                          self, 'pref_algorithm', [i[0] for i in DECOMPOSITION_ALGO],
                          box='Decomposition algorithm',


### PR DESCRIPTION
Fix an error because the parameter was removed.
