### PR TITLE
[FIX] Refactoring: AnyQt

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+This is an issue template. Please fill in the relevant details in the
+sections below.
+-->
+
+##### Data Fusion version
+<!-- From menu _Options→Add-ons→Data Fusion_ -->
+
+
+##### Orange version
+<!-- From menu _Help→About→Version_ or code `Orange.version.full_version` -->
+
+
+##### Expected behavior
+
+
+
+##### Actual behavior
+
+
+
+##### Steps to reproduce the behavior
+
+
+
+##### Additional info (worksheets, data, screenshots, ...)
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+##### Issue
+<!-- E.g. Fixes #1, Implements #2, etc. -->
+<!-- Or a short description, if the issue does not exist. -->
+
+
+##### Description of changes
+
+
+##### Includes
+- [X] Code changes
+- [ ] Tests
+- [ ] Documentation

--- a/orangecontrib/datafusion/widgets/owchaining.py
+++ b/orangecontrib/datafusion/widgets/owchaining.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from PyQt4 import QtCore, QtGui
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import PyTableModel
 
@@ -9,6 +8,7 @@ from orangecontrib.datafusion.models import Relation, FittedFusionGraph
 from orangecontrib.datafusion.widgets.graphview import GraphView, Edge
 from orangecontrib.datafusion.widgets.owfusiongraph import rel_cols
 
+from AnyQt.QtCore import pyqtSignal
 
 class Output:
     RELATION = 'Relation'
@@ -52,7 +52,7 @@ class OWChaining(widget.OWWidget):
         box = gui.widgetBox(self.controlArea, 'Latent chains')
 
         class TableView(gui.TableView):
-            selected_row = QtCore.pyqtSignal(int)
+            selected_row = pyqtSignal(int)
 
             def __init__(self, parent):
                 super().__init__(parent,
@@ -173,6 +173,7 @@ class OWChaining(widget.OWWidget):
 def main():
     # example from https://github.com/marinkaz/scikit-fusion
     import numpy as np
+    from AnyQt.QtWidgets import QApplication
     R12 = np.random.rand(50, 100)
     R32 = np.random.rand(100, 150)
     R33 = np.random.rand(150, 150)
@@ -190,7 +191,7 @@ def main():
         G.add_relation(rel)
     fuser = fusion.Dfmf()
     fuser.fuse(G)
-    app = QtGui.QApplication([])
+    app = QApplication([])
     w = OWChaining()
     w.on_fuser_change(FittedFusionGraph(fuser))
     w.show()

--- a/orangecontrib/datafusion/widgets/owcompletionscoring.py
+++ b/orangecontrib/datafusion/widgets/owcompletionscoring.py
@@ -1,14 +1,16 @@
 from collections import OrderedDict
 
-from PyQt4 import QtCore, QtGui
-from Orange.widgets import widget, gui
-
+import numpy as np
 from skfusion import fusion
+
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QFont
+from AnyQt.QtWidgets import QTableWidgetItem, QTableWidget
+
+from Orange.widgets import widget, gui
 from orangecontrib.datafusion.models import Relation, RelationCompleter
 from orangecontrib.datafusion.widgets.owfusiongraph import \
     relation_str
-
-import numpy as np
 
 
 def _rmse(true, pred):
@@ -50,11 +52,11 @@ class OWCompletionScoring(widget.OWWidget):
 
     def _create_layout(self):
         box = gui.widgetBox(self.mainArea, 'RMSE')
-        BOLD_FONT = QtGui.QFont()
-        BOLD_FONT.setWeight(QtGui.QFont.DemiBold)
+        BOLD_FONT = QFont()
+        BOLD_FONT.setWeight(QFont.DemiBold)
         widget = self
 
-        class HereTableWidget(QtGui.QTableWidget):
+        class HereTableWidget(QTableWidget):
             def __init__(self, parent):
                 super().__init__(parent)
                 parent.layout().addWidget(self)
@@ -85,8 +87,8 @@ class OWCompletionScoring(widget.OWWidget):
                     except ValueError: continue # No fuser could complete this relation
                     for col, rmse in enumerate(rmses):
                         if rmse is None: continue
-                        item = QtGui.QTableWidgetItem('{:.05f}'.format(rmse))
-                        item.setFlags(QtCore.Qt.ItemIsEnabled)
+                        item = QTableWidgetItem('{:.05f}'.format(rmse))
+                        item.setFlags(Qt.ItemIsEnabled)
                         if rmse == min_rmse and len(rmses) > 1:
                             item.setFont(BOLD_FONT)
                         self.setItem(row, col, item)
@@ -116,6 +118,7 @@ class OWCompletionScoring(widget.OWWidget):
 def main():
     from sklearn.datasets import make_blobs
     import numpy as np
+    from AnyQt.QtWidgets import QApplication
     from orangecontrib.datafusion.models import FittedFusionGraph
     from orangecontrib.datafusion.widgets.owmeanfuser import MeanFuser
     X, y = make_blobs(100, 3, centers=2, center_box=(-100, 100), cluster_std=10)
@@ -152,7 +155,7 @@ def main():
     fuserC.name = 'My dfmc<3'
     fuserC.fuse(G)
 
-    app = QtGui.QApplication([])
+    app = QApplication([])
     w = OWCompletionScoring()
     w.on_fuser_change(FittedFusionGraph(fuserF), fuserF.__class__.__name__)
     w.on_fuser_change(FittedFusionGraph(fuserC), fuserC.__class__.__name__)

--- a/orangecontrib/datafusion/widgets/owfusiongraph.py
+++ b/orangecontrib/datafusion/widgets/owfusiongraph.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
 
-from PyQt4 import QtGui
-
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import PyTableModel
 from skfusion import fusion
@@ -235,6 +233,7 @@ class OWFusionGraph(widget.OWWidget):
 def main():
     # example from https://github.com/marinkaz/scikit-fusion
     import numpy as np
+    from AnyQt.QtWidgets import QApplication
     R12 = np.random.rand(50, 100)
     R22 = np.random.rand(100, 100)
     R13 = np.random.rand(50, 40)
@@ -256,7 +255,7 @@ def main():
                  fusion.Relation(R34, t3, t4, name='belong to'),
                  fusion.Relation(R22, t2, t2, name='married to')]
 
-    app = QtGui.QApplication(['asdf'])
+    app = QApplication(['asdf'])
     w = OWFusionGraph()
     w.show()
 

--- a/orangecontrib/datafusion/widgets/owimdbactors.py
+++ b/orangecontrib/datafusion/widgets/owimdbactors.py
@@ -1,5 +1,7 @@
 import sys
-from PyQt4 import QtGui
+
+from AnyQt.QtWidgets import QSizePolicy
+
 from orangecontrib.datafusion.models import Relation
 from Orange.widgets.widget import OWWidget
 from Orange.widgets import widget, gui, settings
@@ -37,8 +39,7 @@ class OWIMDbActors(OWWidget):
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.send_output, default=True)
 
-        self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                                             QtGui.QSizePolicy.Fixed))
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
 
         self.setMinimumWidth(250)
         self.setMaximumWidth(250)
@@ -75,7 +76,8 @@ class OWIMDbActors(OWWidget):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    from AnyQt.QtWidgets import QApplication
+    app = QApplication(sys.argv)
     ow = OWIMDbActors()
     # ow.set_data(movies_users)
     ow.show()

--- a/orangecontrib/datafusion/widgets/owlatentfactors.py
+++ b/orangecontrib/datafusion/widgets/owlatentfactors.py
@@ -1,5 +1,3 @@
-from PyQt4 import QtGui
-
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import PyTableModel
 from skfusion import fusion
@@ -170,6 +168,7 @@ class OWLatentFactors(widget.OWWidget):
 def main():
     # example from https://github.com/marinkaz/scikit-fusion
     import numpy as np
+    from AnyQt.QtWidgets import QApplication
     R12 = np.random.rand(50, 100)
     R32 = np.random.rand(150, 100)
     R33 = np.random.rand(150, 150)
@@ -185,7 +184,7 @@ def main():
         G.add_relation(rel)
     fuser = fusion.Dfmf()
     fuser.fuse(G)
-    app = QtGui.QApplication([])
+    app = QApplication([])
     w = OWLatentFactors()
     w.on_fuser_change(FittedFusionGraph(fuser))
     w.show()

--- a/orangecontrib/datafusion/widgets/owmeanfuser.py
+++ b/orangecontrib/datafusion/widgets/owmeanfuser.py
@@ -1,7 +1,6 @@
 
 from collections import defaultdict
 
-from PyQt4 import QtGui
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import PyTableModel
 
@@ -171,6 +170,7 @@ class OWMeanFuser(widget.OWWidget):
 
 
 def main():
+    from AnyQt.QtWidgets import QApplication
     t1 = fusion.ObjectType('Users', 10)
     t2 = fusion.ObjectType('Movies', 30)
     t3 = fusion.ObjectType('Actors', 40)
@@ -196,7 +196,7 @@ def main():
     ]
     G = fusion.FusionGraph()
     G.add_relations_from(relations)
-    app = QtGui.QApplication([])
+    app = QApplication([])
     w = OWMeanFuser()
     w.on_fusion_graph_change(G)
     w.show()

--- a/orangecontrib/datafusion/widgets/owmoviegenres.py
+++ b/orangecontrib/datafusion/widgets/owmoviegenres.py
@@ -1,10 +1,11 @@
 import sys
-from orangecontrib.datafusion import movielens
 import numpy as np
-from PyQt4 import QtGui
-from PyQt4.QtGui import QGridLayout
+
+from AnyQt.QtWidgets import QGridLayout, QSizePolicy
+
 from Orange.widgets.widget import OWWidget
 from Orange.widgets import widget, gui
+from orangecontrib.datafusion import movielens
 from orangecontrib.datafusion.models import Relation
 
 from skfusion import fusion
@@ -34,8 +35,7 @@ class OWMovieGenres(OWWidget):
         self.layout = QGridLayout()
         self.genrebox = gui.widgetBox(self.controlArea, "Genres")
 
-        self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                           QtGui.QSizePolicy.Fixed))
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
         self.setMinimumWidth(250)
 
     def update_genres(self):
@@ -78,7 +78,8 @@ class OWMovieGenres(OWWidget):
             self.send("Genres", Relation(relation))
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    from AnyQt.QtWidgets import QApplication
+    app = QApplication(sys.argv)
     ow = OWMovieGenres()
     #ow.set_data(movies)
     ow.show()

--- a/orangecontrib/datafusion/widgets/owmovieratings.py
+++ b/orangecontrib/datafusion/widgets/owmovieratings.py
@@ -1,5 +1,7 @@
 import sys
-from PyQt4 import QtGui
+
+from AnyQt.QtWidgets import QSizePolicy
+
 from Orange.widgets.widget import OWWidget
 from Orange.widgets import widget, gui, settings
 from orangecontrib.datafusion.models import Relation
@@ -47,8 +49,7 @@ class OWMovieRatings(OWWidget):
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.send_output, default=True)
 
-        self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                           QtGui.QSizePolicy.Fixed))
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
 
         self.setMinimumWidth(250)
         self.setMaximumWidth(250)
@@ -77,7 +78,8 @@ class OWMovieRatings(OWWidget):
         self.send("Ratings", Relation(relation))
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    from AnyQt.QtWidgets import QApplication
+    app = QApplication(sys.argv)
     ow = OWMovieRatings()
     ow.show()
     app.exec_()

--- a/orangecontrib/datafusion/widgets/owsamplematrix.py
+++ b/orangecontrib/datafusion/widgets/owsamplematrix.py
@@ -1,8 +1,10 @@
 import sys
 import copy
-import Orange.data.table
-from PyQt4 import QtGui
-from PyQt4.QtCore import Qt
+
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QGridLayout, QSizePolicy
+
+from Orange.data import Table
 from Orange.widgets.widget import OWWidget
 from Orange.widgets import widget, gui, settings
 from skfusion import fusion
@@ -56,7 +58,7 @@ class OWSampleMatrix(OWWidget):
     want_main_area = False
     resizing_enabled = False
 
-    inputs = [("Data", Orange.data.table.Table, "set_data", widget.Default)]
+    inputs = [("Data", Table, "set_data", widget.Default)]
     outputs = [(Output.IN_SAMPLE_DATA, Relation),
                (Output.OUT_OF_SAMPLE_DATA, Relation)]
 
@@ -68,13 +70,13 @@ class OWSampleMatrix(OWWidget):
         super().__init__()
         self.data = None
 
-        form = QtGui.QGridLayout()
+        form = QGridLayout()
 
         self.row_type = ""
-        w_rowtype = gui.lineEdit(self.controlArea, self, "row_type", "Row Type", callback=self.send_output)
+        gui.lineEdit(self.controlArea, self, "row_type", "Row Type", callback=self.send_output)
 
         self.col_type = ""
-        w_coltype = gui.lineEdit(self.controlArea, self, "col_type", "Column Type", callback=self.send_output)
+        gui.lineEdit(self.controlArea, self, "col_type", "Column Type", callback=self.send_output)
 
         methodbox = gui.radioButtonsInBox(
             self.controlArea, self, "method", [],
@@ -93,16 +95,13 @@ class OWSampleMatrix(OWWidget):
         form.addWidget(entries, 1, 1, Qt.AlignLeft)
 
         sample_size = gui.widgetBox(self.controlArea, "Proportion of data in the sample")
-        percent = gui.hSlider(
-            sample_size, self, 'percent', minValue=1, maxValue=100, step=5,
-            ticks=10, labelFormat=" %d%%")
+        gui.hSlider(sample_size, self, 'percent', minValue=1, maxValue=100, step=5, ticks=10,
+                    labelFormat=" %d%%")
 
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.send_output, default=True)
 
-        self.setSizePolicy(
-            QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                              QtGui.QSizePolicy.Fixed))
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
 
         self.setMinimumWidth(250)
         self.send_output()
@@ -149,7 +148,8 @@ class OWSampleMatrix(OWWidget):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    from AnyQt.QtWidgets import QApplication
+    app = QApplication(sys.argv)
     ow = OWSampleMatrix()
     # ow.set_data(Orange.data.Table("housing.tab"))
     ow.send_output()

--- a/orangecontrib/datafusion/widgets/owtabletorelation.py
+++ b/orangecontrib/datafusion/widgets/owtabletorelation.py
@@ -1,5 +1,6 @@
-from PyQt4.QtGui import QTableView, QGridLayout, QWidget
-from PyQt4.QtCore import Qt, QSize
+from AnyQt.QtWidgets import QTableView, QGridLayout, QWidget
+from AnyQt.QtCore import Qt, QSize
+
 from Orange.data import Table, Domain
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
 from Orange.widgets.utils.itemmodels import TableModel
@@ -177,11 +178,10 @@ class OWTableToRelation(OWWidget):
 
 
 if __name__ == '__main__':
-    from PyQt4.QtGui import QApplication
-    import Orange
+    from AnyQt.QtWidgets import QApplication
     app = QApplication([])
     ow = OWTableToRelation()
-    ow.set_data(Orange.data.Table('zoo'))
+    ow.set_data(Table('zoo'))
     ow.show()
     app.exec()
     ow.saveSettings()


### PR DESCRIPTION
Use `AnyQt` instead of `PyQt4`.
Three minor fixes in **Matrix Sampler** widget (unused variables removed).

Also add GitHub templates.