### PR TITLE
[FIX] OWFusionGraph throws exception

### DIFF
--- a/orangecontrib/datafusion/widgets/owfusiongraph.py
+++ b/orangecontrib/datafusion/widgets/owfusiongraph.py
@@ -116,7 +116,6 @@ class OWFusionGraph(widget.OWWidget):
             def selectionChanged(self, selected, deselected):
                 super().selectionChanged(selected, deselected)
                 if not selected:
-                    assert len(deselected) > 0
                     relation = None
                 else:
                     assert len(selected) == 1


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #26.

##### Description of changes
When the widget is first added on canvas it used to call assert len(deselected) > 0, but since the widget is still empty, len(deselected) is 0, resulting in an error.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
